### PR TITLE
MAP_SHARED first pass

### DIFF
--- a/kernel/devfs.c
+++ b/kernel/devfs.c
@@ -153,6 +153,12 @@ int devfs_setup()
     /* /dev/fd symlink */
     _devfs->fs_symlink(_devfs, "/proc/self/fd", "/fd");
 
+    if (myst_mkdirhier("/dev/shm", 777) != 0)
+    {
+        myst_eprintf("cannot create /dev/shm directory \n");
+        ERAISE(-EINVAL);
+    }
+
 done:
     return ret;
 }


### PR DESCRIPTION
Maintain a list of shared mappings. If an existing mapping with the same
(filename, offset, length) triple is encountered in mmap, instead of
creating a new mapping the existing mapping is returned.

On unmapping, the reference count of the shared region is decrmented.
The mapping is released when the reference count drops to zero.

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>