### PR TITLE
Process signals after clearing wait queues

### DIFF
--- a/kernel/tcall.c
+++ b/kernel/tcall.c
@@ -65,8 +65,6 @@ long myst_tcall_wait(uint64_t event, const struct timespec* timeout)
     params[0] = (long)event;
     params[1] = (long)timeout;
     long ret = myst_tcall(MYST_TCALL_WAIT, params);
-    // check for signals
-    myst_signal_process(myst_thread_self());
     return ret;
 }
 


### PR DESCRIPTION
Currently we check for outstanding signals on the return path in
myst_tcall_wait. This short-circuiting can leave the higher level
synchronization mechanims like condition variables and mutexes in an
inconsistent state.
This patch moves the signal processing check into mutex and cond variable
implementation.

Signed-off-by: Vikas Tikoo <vitikoo@microsoft.com>